### PR TITLE
include stdint.h in sector.h

### DIFF
--- a/ping360_sonar/include/ping360_sonar/sector.h
+++ b/ping360_sonar/include/ping360_sonar/sector.h
@@ -4,6 +4,8 @@
 #include <map>
 #include <math.h>
 #include <vector>
+#include <stdint.h>
+
 
 namespace ping360_sonar
 {


### PR DESCRIPTION
Hello,

When building this package in a raspberry pi 3 running blueOS v1.0.1 I encountered the following error:

```
In file included from /home/pi/bluerov_ws/src/ping360_sonar/ping360_sonar/src/sector.cpp:1:
/home/pi/bluerov_ws/src/ping360_sonar/ping360_sonar/include/ping360_sonar/sector.h:46:25: error: ‘uint16_t’ has not been declared
   46 |   inline void configure(uint16_t samples, int half_size)
      |                         ^~~~~~~~
gmake[2]: *** [CMakeFiles/ping360_node.dir/build.make:121: CMakeFiles/ping360_node.dir/src/sector.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:117: CMakeFiles/ping360_node.dir/all] Error 2
gmake: *** [Makefile:160: all] Error 2
```

To fix it, I only had to include stdint.h in sector.h
This PR contains this change

